### PR TITLE
Configure resource filtering and pom properties from external file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,4 @@ src/main/resources/.DS_Store
 
 src/main/resources/app.properties
 src/main/resources/dev.properties
-src/main/resources/deployment.properties
+src/main/resources/server.properties

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ richardburton.iml
 src/main/resources/.DS_Store
 /src/main/resources/dev.properties
 src/main/resources/META-INF/persistence.xml
+src/main/resources/deployment.properties
 
 src/test/resources/test-persistence.xml
 src/test/resources/test-persistence_mysql.xml

--- a/.gitignore
+++ b/.gitignore
@@ -27,15 +27,12 @@ target/
 *.project
 .settings
 .vscode/*
-src/main/resources/app.properties
+
 .DS_Store
 .idea
 richardburton.iml
 src/main/resources/.DS_Store
-/src/main/resources/dev.properties
-src/main/resources/META-INF/persistence.xml
-src/main/resources/deployment.properties
 
-src/test/resources/test-persistence.xml
-src/test/resources/test-persistence_mysql.xml
-src/test/resources/arquillian.xml
+src/main/resources/app.properties
+src/main/resources/dev.properties
+src/main/resources/deployment.properties

--- a/README.md
+++ b/README.md
@@ -1,18 +1,63 @@
 # richardburton-api
 
-## Keytool Generator
-
-`keytoolcommand = keytool -genseckey -keyalg AES -alias jwtsecretkey -keystore keys@richardburton -keysize 256`
-
 ## app.properties
 
-A properties file `app.properties` must be placed in src/main/resources folder. The format is `key=value`. It must specify:
+A properties file `app.properties` containing app-specific configuration must be placed under `src/main/resources` folder.
+Below is a template with some defaults and {PLACEHOLDERS}.
 
-- `keystoreloc`: the location of the KeyStore generated with Keytool.
-- `jwtkeyalias`: the alias of the Key generated with Keytool.
-- `keystorepsw`: the password of the KeyStore generated with Keytool.
+```
+richardburton.home={HOME DIRECTORY TO APP DATA}
 
-## dev.properties
+# KeyStore configuration
+
+keystore.location=${richardburton.home}/security
+keystore.name=keys@richardburton
+keystore.instanceType=PKCS12
+keystore.algorithm=HmacSHA256
+
+keystore.keys.jwt=jwtsecretkey
+
+# JWT Token configuration
+
+jwt.ttlms=2100000
+jwt.issuer=https://richardburton-api.canoas.ifrs.edu.br
+
+# Hibernate Search configuration
+
+hibernate.search.indexBase=${richardburton.home}/indexes
+hibernate.search.test.indexBase=${richardburton.home}/test/indexes
+```
+
+## server.properties
+
+A properties file `server.properties` containing server-specific configuration must be placed under `src/main/resources` folder.
+Below is a template with some defaults and {PLACEHOLDERS}.
+
+```
+# Main server configuration
+
+wildfly.host=localhost
+wildfly.management.username={WILDFLY MANAGEMENT USER USERNAME}
+wildfly.management.password={WILDFLY MANAGEMENT USER PASSWORD}
+wildfly.management.port=9990
+wildfly.datasource.name=java:jboss/datasources/RichardBurtonDS
+wildfly.datasource.dialect=org.hibernate.dialect.PostgreSQL95Dialect
+wildfly.datasource.hbm2dll.auto=create-drop
+
+# Testing server configuration
+
+wildfly.test.host=localhost
+wildfly.test.port=8080
+wildfly.test.management.username={TESTING WILDFLY INSTANCE MANAGEMENT USER USERNAME}
+wildfly.test.management.password={TESTING WILDFLY INSTANCE  MANAGEMENT USER PASSWORD}
+wildfly.test.management.address=127.0.0.1
+wildfly.test.management.port=9990
+wildfly.test.datasource.name=java:jboss/datasources/RichardBurtonTestingDS
+wildfly.test.datasource.dialect=org.hibernate.dialect.H2Dialect
+```
+
+
+## dev.properties (THIS WILL BE REMOVED SOON)
 
 A properties file `dev.properties` must be placed in src/main/resources folder. The format is `key=value`. It must specify:
 
@@ -24,128 +69,9 @@ This CSV contains one TranslatedBook Publication per line, formmated like:
 
 Escape `;` putting the whole field in double quotes. For several translators, separate them with `&`.
 
-## persistence.xml
 
-A configuration file for JPA `persistence.xml` must be placed in src/main/resources/META-INF folder.
-Here is an example, of what it should look like.
+## Wildfly Configuration
 
-- `LUCENE_INDEX_BASE` must be set to the actual Apache Lucene index directory. It could be any directory where the user has enough privileges to read, write, create and delete files. If this is not set, Hibernate Search won't work.
+The Wildfly Application Server `standalone.xml` must be configured to support the application. The main deployment instance must have a datasource with `jndi-name` equal to the property `wildfly.datasource.name` in `server.properties`. The same applies to the test instance, whose datasources's `jndi-name` must be equal to the property `wildfly.test.datasource.name` in `server.properties`. **Both instances may be the same, case in which two different datasources must be configured for testing and production**. The datasource dialect properties must be compatible with the database server used.
 
-```
-<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
-             version="2.1">
-
-    <persistence-unit name="richardburton_development">
-        <description>RichardBurton Development DB</description>
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
-        <jta-data-source>java:jboss/datasources/RichardBurtonDevelopDS</jta-data-source>
-
-        <properties>
-            <property name="hibernate.show_sql" value="false"/>
-            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect"/>
-            <property name="hibernate.search.default.directory_provider" value="filesystem"/>
-            <property name="hibernate.search.default.indexBase" value="LUCENE_INDEX_BASE"/>
-        </properties>
-
-    </persistence-unit>
-</persistence>
-```
-</persistence>
-
-
-## standalone.xml
-
-Wildfly configuration `standalone.xml` file must include Development and Testing datasources. In this case, these are configured as a MySQL Database and a H2 Database, respectively. `sa` is the default username and password for the H2 database embedded in Wildfly. `DEVELOPMENT_DATABASE_USERNAME` and `DEVELOPMENT_DATABASE_USERPASSWORD` MUST be replaced with the actual ones, or deployment will fail.
-
-```
-<datasources>
-  <datasource jndi-name="java:jboss/datasources/RichardBurtonDevelopDS" pool-name="richardburton-develop-ds-pool" enabled="true" use-java-context="true">
-    <connection-url>jdbc:mysql://localhost:3306/richardburton_develop?useUnicode=true&amp;character_set_server=utf8mb4&amp;autoReconnect=true&amp;zeroDateTimeBehavior=convertToNull</connection-url>
-    <driver>mysql</driver>
-    <security>
-      <user-name>DEVELOPMENT_DATABASE_USERNAME</user-name>
-      <password>DEVELOPMENT_DATABASE_USERPASSWORD</password>
-    </security>
-  </datasource>
-   
-  <datasource jndi-name="java:jboss/datasources/RichardBurtonTestingH2DS" pool-name="richardburton-testing-h2ds-pool" enabled="true" use-java-context="true" statistics-enabled="${wildfly.datasources.statistics-enabled:${wildfly.statistics-enabled:false}}">
-    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
-    <driver>h2</driver>
-    <security>
-      <user-name>sa</user-name>
-      <password>sa</password>
-    </security>
-   </datasource>
-   <drivers>
-      <driver name="h2" module="com.h2database.h2">
-        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-      </driver>
-      <driver name="mysql" module="com.mysql">
-          <driver-class>com.mysql.cj.jdbc.Driver</driver-class>
-          <xa-datasource-class>com.mysql.cj.jdbc.MysqlXADataSource</xa-datasource-class>
-      </driver>
-  </drivers>
-</datasources>
-```
-
-## test-persistence.xml
-
-A `test-persistence.xml` file must be placed inside `src/test/resources`. With the above datasource configuration, it sould look like this.
-
-- `LUCENE_INDEX_BASE` must be set to the actual Apache Lucene index directory. It could be any directory where the user has enough privileges to read, write, create and delete files. If this is not set, Hibernate Search won't work.
-
-```
-<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
-             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
-             version="2.1">
-
-    <persistence-unit name="richardburton_testing">
-        <description>RichardBurton Testing DB</description>
-        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
-        <jta-data-source>java:jboss/datasources/RichardBurtonTestingH2DS</jta-data-source>
-
-        <properties>
-            <property name="hibernate.show_sql" value="false"/>
-            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
-            <property name="hibernate.search.default.directory_provider" value="filesystem"/>
-            <property name="hibernate.search.default.indexBase" value="LUCENE_INDEX_BASE"/>
-        </properties>
-
-    </persistence-unit>
-
-</persistence>
-```
-
-## arquillian.xml
-
-An Arquillian Configuration File must be placed inside `src/test/resources`, in order to run in-container integration tests. It should look like this. `WILDFLY_USERNAME` and `WILDFLY_PASSWORD` MUST be the actual credentials to a Wildfly Administrative User. 
-
-```
-<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-            xmlns="http://jboss.org/schema/arquillian" xsi:schemaLocation="
-        http://jboss.org/schema/arquillian
-        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
-
-    <!-- Sets the protocol which is how Arquillian talks and executes the tests inside the container -->
-    <defaultProtocol type="Servlet 3.0"/>
-
-    <!-- Configuration to be used when the WildFly remote profile is active -->
-    <container qualifier="wildfly-remote" default="true">
-        <protocol type="Servlet 3.0">
-            <property name="host">localhost</property>
-            <property name="port">8080</property>
-        </protocol>
-        <configuration>
-            <property name="managementAddress">127.0.0.1</property>
-            <property name="managementPort">9990</property>
-            <property name="username">WILDFLY_USERNAME</property>
-            <property name="password">WILDFLY_PASSWORD</property>
-        </configuration>
-    </container>
-</arquillian>
-```
-            
+[Here is an example of how to configure a PostgreSQL datasource.](https://www.stenusys.com/how_to_setup_postgresql_datasource_with_wildfly/)

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <properties>
 
         <app.properties>src/main/resources/app.properties</app.properties>
-        <deployment.properties>src/main/resources/deployment.properties</deployment.properties>
+        <server.properties>src/main/resources/server.properties</server.properties>
         <jdk.version>13</jdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -230,7 +230,7 @@
 
         <filters>
             <filter>${app.properties}</filter>
-            <filter>${deployment.properties}</filter>
+            <filter>${server.properties}</filter>
         </filters>
 
         <resources>
@@ -264,7 +264,7 @@
                         <configuration>
                             <files>
                                 <file>${app.properties}</file>
-                                <file>${deployment.properties}</file>
+                                <file>${server.properties}</file>
                             </files>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,12 @@
     <packaging>war</packaging>
 
     <properties>
+
+        <app.properties>src/main/resources/app.properties</app.properties>
+        <deployment.properties>src/main/resources/deployment.properties</deployment.properties>
+        <jdk.version>13</jdk.version>
+
+        <project.build.finalName>richardburton</project.build.finalName>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -139,7 +145,6 @@
             <scope>provided</scope>
         </dependency>
 
-
         <!-- Jackson -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -152,7 +157,6 @@
             <artifactId>jackson-jaxrs-json-provider</artifactId>
             <version>2.10.1</version>
         </dependency>
-
 
         <!-- JJWT -->
         <dependency>
@@ -217,9 +221,53 @@
     </dependencies>
 
     <build>
-        <finalName>richardburton</finalName>
+        <filters>
+            <filter>${app.properties}</filter>
+        </filters>
+
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
 
         <plugins>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>properties-maven-plugin</artifactId>
+                <version>1.0.0</version>
+
+                <executions>
+                    <execution>
+                        <id>load-to-initialize</id>
+                        <phase>initialize</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${app.properties}</file>
+                                <file>${deployment.properties}</file>
+                            </files>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>load-to-clean</id>
+                        <phase>pre-clean</phase>
+                        <goals>
+                            <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                            <files>
+                                <file>${app.properties}</file>
+                            </files>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -227,7 +275,8 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <directory>/Users/andres/richardburton/lucene/indexes</directory>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <directory>${hsearch_indexes_dir}</directory>
                             <includes>
                                 <include>**/*</include>
                             </includes>
@@ -261,8 +310,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>13</source>
-                    <target>13</target>
+                    <source>${jdk.version}</source>
+                    <target>${jdk.version}</target>
                 </configuration>
             </plugin>
 
@@ -273,17 +322,12 @@
                 <version>2.0.1.Final</version>
                 <configuration>
                     <filename>${project.build.finalName}.war</filename>
-                    <username>richardburton</username>
-                    <password>admin@richardburton</password>
 
-                    <commands>
-                        <command>
-                            /subsystem=logging/file-handler=debug:add(level=DEBUG,autoflush=true,file={"relative-to"=>"jboss.server.log.dir",
-                            "path"=>"debug.log"})
-                        </command>
-                        <command>/subsystem=logging/logger=org.jboss.as:add(level=DEBUG,handlers=[debug])</command>
-                    </commands>
+                    <!--suppress UnresolvedMavenProperty -->
+                    <username>${wildfly.username}</username>
 
+                    <!--suppress UnresolvedMavenProperty -->
+                    <password>${wildfly.password}</password>
                 </configuration>
                 <executions>
                     <execution>
@@ -294,7 +338,6 @@
                     </execution>
                 </executions>
             </plugin>
-
 
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,6 @@
         <app.properties>src/main/resources/app.properties</app.properties>
         <deployment.properties>src/main/resources/deployment.properties</deployment.properties>
         <jdk.version>13</jdk.version>
-
-        <project.build.finalName>richardburton</project.build.finalName>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -227,6 +225,9 @@
     </dependencies>
 
     <build>
+
+        <finalName>richardburton</finalName>
+
         <filters>
             <filter>${app.properties}</filter>
             <filter>${deployment.properties}</filter>
@@ -338,7 +339,7 @@
 
                     <username>${wildfly.management.username}</username>
                     <password>${wildfly.management.password}</password>
-                    <hostname>${wildfly.management.address}</hostname>
+                    <hostname>${wildfly.host}</hostname>
                     <port>${wildfly.management.port}</port>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -218,11 +218,18 @@
             <type>pom</type>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.8.1</version>
+        </dependency>
+
     </dependencies>
 
     <build>
         <filters>
             <filter>${app.properties}</filter>
+            <filter>${deployment.properties}</filter>
         </filters>
 
         <resources>
@@ -231,6 +238,13 @@
                 <filtering>true</filtering>
             </resource>
         </resources>
+
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
 
         <plugins>
 
@@ -275,8 +289,7 @@
                 <configuration>
                     <filesets>
                         <fileset>
-                            <!--suppress UnresolvedMavenProperty -->
-                            <directory>${hsearch_indexes_dir}</directory>
+                            <directory>${hibernate.search.indexBase}</directory>
                             <includes>
                                 <include>**/*</include>
                             </includes>
@@ -323,11 +336,10 @@
                 <configuration>
                     <filename>${project.build.finalName}.war</filename>
 
-                    <!--suppress UnresolvedMavenProperty -->
-                    <username>${wildfly.username}</username>
-
-                    <!--suppress UnresolvedMavenProperty -->
-                    <password>${wildfly.password}</password>
+                    <username>${wildfly.management.username}</username>
+                    <password>${wildfly.management.password}</password>
+                    <hostname>${wildfly.management.address}</hostname>
+                    <port>${wildfly.management.port}</port>
                 </configuration>
                 <executions>
                     <execution>

--- a/src/main/java/br/edu/ifrs/canoas/richardburton/Initializer.java
+++ b/src/main/java/br/edu/ifrs/canoas/richardburton/Initializer.java
@@ -1,0 +1,16 @@
+package br.edu.ifrs.canoas.richardburton;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class Initializer implements ServletContextListener {
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+
+        RichardBurton.setup();
+    }
+
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,18 @@
+<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="richardburton">
+        <description>RichardBurton Persistence Unit</description>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <jta-data-source>${wildfly.datasource.name}</jta-data-source>
+
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="${wildfly.datasource.hbm2dll.auto}"/>
+            <property name="hibernate.dialect" value="${wildfly.datasource.dialect}"/>
+            <property name="hibernate.search.default.directory_provider" value="filesystem"/>
+            <property name="hibernate.search.default.indexBase" value="${hibernate.search.indexBase}"/>
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/src/test/java/br/edu/ifrs/canoas/richardburton/TestInitializer.java
+++ b/src/test/java/br/edu/ifrs/canoas/richardburton/TestInitializer.java
@@ -1,0 +1,46 @@
+package br.edu.ifrs.canoas.richardburton;
+
+import io.undertow.util.FileUtils;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+@WebListener
+public class TestInitializer implements ServletContextListener {
+
+    private static String TEST_INDEX_BASE = "hibernate.search.test.indexBase";
+
+    @Override
+    public void contextInitialized(ServletContextEvent servletContextEvent) {
+
+        InputStream propertiesStream = TestInitializer.class.getClassLoader().getResourceAsStream("app.properties");
+        Properties properties = new Properties();
+
+        try {
+
+            properties.load(propertiesStream);
+
+        } catch (IOException e) {
+
+            throw new RuntimeException(e);
+        }
+
+        try {
+
+            File testIndexBase = new File(properties.getProperty(TEST_INDEX_BASE));
+            if (testIndexBase.exists()) FileUtils.deleteRecursive(testIndexBase.toPath());
+            if(!testIndexBase.mkdirs()) throw new RuntimeException("Could not create test index base directory");
+
+        } catch (IOException e) {
+
+            throw new RuntimeException(e);
+        }
+
+    }
+
+}

--- a/src/test/java/br/edu/ifrs/canoas/richardburton/session/SessionClientCreateIT.java
+++ b/src/test/java/br/edu/ifrs/canoas/richardburton/session/SessionClientCreateIT.java
@@ -17,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.persistence.criteria.CriteriaBuilder;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -33,15 +34,18 @@ public class SessionClientCreateIT {
     public static WebArchive createDeployment() {
 
         return ShrinkWrap.create(WebArchive.class).addClass(Session.class)
-                .addClass(RichardBurton.class)
+                .addClasses(RichardBurton.class, Initializer.class, TestInitializer.class)
                 .addClasses(ApplicationResource.class, CORSFilter.class)
                 .addClasses(DAO.class, DAOImpl.class)
                 .addClasses(EntityService.class, EntityServiceImpl.class)
-                .addClasses(DuplicateEntityException.class, EntityValidationException.class,
-                        EntityNotFoundException.class)
+                .addClasses(DuplicateEntityException.class, EntityValidationException.class, EntityNotFoundException.class)
                 .addPackage(UserResource.class.getPackage()).addPackage(SessionResource.class.getPackage())
-                .addAsLibraries(Maven.resolver().loadPomFromFile(new File("pom.xml"))
-                        .resolve("io.jsonwebtoken:jjwt:0.9.1").withTransitivity().asFile())
+                .addAsLibraries(
+                        Maven.resolver()
+                                .loadPomFromFile(new File("pom.xml"))
+                                .resolve("io.jsonwebtoken:jjwt:0.9.1")
+                                .withTransitivity()
+                                .asFile())
                 .addAsResource("test-persistence.xml", "META-INF/persistence.xml")
                 .addAsResource("app.properties", "app.properties");
     }

--- a/src/test/java/br/edu/ifrs/canoas/richardburton/users/UserClientCreateIT.java
+++ b/src/test/java/br/edu/ifrs/canoas/richardburton/users/UserClientCreateIT.java
@@ -29,12 +29,14 @@ public class UserClientCreateIT {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class).addClass(Session.class)
+                .addClass(TestInitializer.class)
                 .addClasses(ApplicationResource.class, CORSFilter.class).addClasses(DAO.class, DAOImpl.class)
                 .addClasses(EntityService.class, EntityServiceImpl.class)
                 .addClasses(DuplicateEntityException.class, EntityValidationException.class,
                         EntityNotFoundException.class)
                 .addPackage(UserResource.class.getPackage())
-                .addAsResource("test-persistence.xml", "META-INF/persistence.xml");
+                .addAsResource("test-persistence.xml", "META-INF/persistence.xml")
+                .addAsResource("app.properties", "app.properties");
     }
 
     @Before

--- a/src/test/resources/arquillian.xml
+++ b/src/test/resources/arquillian.xml
@@ -1,0 +1,22 @@
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian" xsi:schemaLocation="
+        http://jboss.org/schema/arquillian
+        http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <!-- Sets the protocol which is how Arquillian talks and executes the tests inside the container -->
+    <defaultProtocol type="Servlet 3.0"/>
+
+    <!-- Configuration to be used when the WildFly remote profile is active -->
+    <container qualifier="wildfly-remote" default="true">
+        <protocol type="Servlet 3.0">
+            <property name="host">${wildfly.test.host}</property>
+            <property name="port">${wildfly.test.port}</property>
+        </protocol>
+        <configuration>
+            <property name="managementAddress">${wildfly.test.management.address}</property>
+            <property name="managementPort">${wildfly.test.management.port}</property>
+            <property name="username">${wildfly.test.management.username}</property>
+            <property name="password">${wildfly.test.management.password}</property>
+        </configuration>
+    </container>
+</arquillian>

--- a/src/test/resources/test-persistence.xml
+++ b/src/test/resources/test-persistence.xml
@@ -1,0 +1,21 @@
+<persistence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="richardburton_testing">
+        <description>RichardBurton Testing Persistence Unit</description>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+        <jta-data-source>${wildfly.test.datasource.name}</jta-data-source>
+
+        <properties>
+
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.dialect" value="${wildfly.test.datasource.dialect}"/>
+            <property name="hibernate.search.default.directory_provider" value="filesystem"/>
+            <property name="hibernate.search.default.indexBase" value="${hibernate.search.test.indexBase}"/>
+        </properties>
+
+    </persistence-unit>
+
+</persistence>


### PR DESCRIPTION
Maven-Resource-Plugin has been configured to filter resources in `src/main/resources` and `src/test/resources`. This allows to define variables in external files and use them in configuration files (such as `persistence.xml` and `arquillian.xml`) through string interpolation. Also, Maven-Properties-Plugin has been configured to read project properties from the same properties files used in resource filtering. Now, `persistence.xml`, `test-persistence.xml` and `arquillian.xml` are added to the repository and their environment-specific configuration is set in two properties files:

- `app.properties`, containing all app-specific configuration, for example, the home directory, the keystore location and the index base.

- `server.properties` containing all server-specific configuration, such as wildfly credentials and datasource configuration.

A `RichardBurton::setup` method is defined and configured to be executed at startup. This method creates all the necessary directories needed to contain the app's data. Now, KeyStore is recreated at startup, using a random password that is only valid through a single execution period. This avoids putting the keystore's password in app.properties. Just the location and the name is needed.